### PR TITLE
⬆️ bump dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
         "supertest": "^7.0.0",
         "tsc": "^2.0.4",
         "tsup": "^8.0.2",
-        "tsx": "^4.11.0",
+        "tsx": "^4.13.1",
         "typescript": "^5.4.5",
         "vite-tsconfig-paths": "^4.3.2",
         "vitest": "^1.6.0",
@@ -7637,9 +7637,9 @@
       }
     },
     "node_modules/tsx": {
-      "version": "4.11.0",
-      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.11.0.tgz",
-      "integrity": "sha512-vzGGELOgAupsNVssAmZjbUDfdm/pWP4R+Kg8TVdsonxbXk0bEpE1qh0yV6/QxUVXaVlNemgcPajGdJJ82n3stg==",
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.13.1.tgz",
+      "integrity": "sha512-MU1IshdvSdIvf0U9ofr5ZWCWjLAPvf5gIvRZygGisoA/fq/FmSxjAfLIxF8ZoZtvHffY1NRkmxIR5/RW1Qc84g==",
       "dev": true,
       "dependencies": {
         "esbuild": "~0.20.2",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "supertest": "^7.0.0",
     "tsc": "^2.0.4",
     "tsup": "^8.0.2",
-    "tsx": "^4.11.0",
+    "tsx": "^4.13.1",
     "typescript": "^5.4.5",
     "vite-tsconfig-paths": "^4.3.2",
     "vitest": "^1.6.0",


### PR DESCRIPTION
- **:arrow_up: Bump @scalar/fastify-api-reference from 1.22.52 to 1.23.5**
- **:arrow_up: Bump tsup from 8.0.2 to 8.1.0**
- **:arrow_up: Bump prisma from 5.14.0 to 5.15.0**
- **:arrow_up: Bump @types/node from 20.12.12 to 20.14.2**
- **:arrow_up: Bump tsx from 4.11.0 to 4.13.1**
